### PR TITLE
Insert material in GET parameters for the order.

### DIFF
--- a/src/components/nozzle/ui/PropertyPanel.tsx
+++ b/src/components/nozzle/ui/PropertyPanel.tsx
@@ -8,6 +8,11 @@ import { Material, useNozzleStore } from "@/stores/nozzle"
 import { useSettingsStore } from "@/stores/settings"
 import CustomSlider from "./CustomSlider"
 
+const Materials = {
+  "bronze": "真鍮",
+  "high-wear-steel": "高耐摩耗鋼",
+} as const;
+
 export const PropertyPanel: React.FC = () => {
   const {updateNodeProperty,nodeIds} = useModularStore()
   const {length,outerSize,tipInnerSize,tipOuterSize,needleLength,updateNozzle,material} = useNozzleStore()
@@ -36,7 +41,7 @@ export const PropertyPanel: React.FC = () => {
             <button
               className={material === "bronze" ? "t-tab-active" : ""}
               onClick={() => updateNozzle({ material: "bronze" as Material })}>
-              真鍮
+              {Materials.bronze}
             </button>
             <span className="bg-transparent"></span>
             <button
@@ -44,7 +49,7 @@ export const PropertyPanel: React.FC = () => {
               onClick={() =>
                 updateNozzle({ material: "high-wear-steel" as Material })
               }>
-              高耐摩耗鋼
+              {Materials["high-wear-steel"]}
             </button>
           </div>
         </div>
@@ -225,7 +230,7 @@ export const PropertyPanel: React.FC = () => {
         </div>
         <a
           className="border-[1px] border-content-h-a px-4 py-2 text-sm hover:bg-content-h-a hover:text-content-dark-h-a w-full mt-2 transition-all text-center"
-          href={`https://docs.google.com/forms/d/e/1FAIpQLSf5L-INqDqmH0yHtx1aOoFguA1MpkODBXZIua-5Bm2t3KBU6Q/viewform?usp=pp_url&entry.1225353679=${encodeURIComponent(length)}&entry.11693644=${encodeURIComponent(outerSize)}&entry.1455151050=${encodeURIComponent(tipInnerSize)}&entry.300096431=${encodeURIComponent(tipOuterSize)}&entry.1298909336=${encodeURIComponent(needleLength)}`}
+          href={`https://docs.google.com/forms/d/e/1FAIpQLSf5L-INqDqmH0yHtx1aOoFguA1MpkODBXZIua-5Bm2t3KBU6Q/viewform?usp=pp_url&entry.290740902=${encodeURIComponent(Materials[material])}&entry.1225353679=${encodeURIComponent(length)}&entry.11693644=${encodeURIComponent(outerSize)}&entry.1455151050=${encodeURIComponent(tipInnerSize)}&entry.300096431=${encodeURIComponent(tipOuterSize)}&entry.1298909336=${encodeURIComponent(needleLength)}`}
           target={"_blank"}
           >
           ORDER

--- a/src/stores/nozzle.ts
+++ b/src/stores/nozzle.ts
@@ -1,6 +1,5 @@
 import { create } from 'zustand';
 
-
 export type Material = "bronze"|"high-wear-steel";
 
 interface NozzleStore {


### PR DESCRIPTION
This pull request refactors the `PropertyPanel` component in `src/components/nozzle/ui/PropertyPanel.tsx` to improve code maintainability and readability. The changes introduce a centralized `Materials` object for material labels, ensuring consistent usage across the UI and form submissions. Additionally, the `Material` type definition in `src/stores/nozzle.ts` remains unchanged but is referenced in the updates.

### Refactoring for Material Labels:

* Introduced a `Materials` object to centralize material labels (`bronze` and `high-wear-steel`) in `src/components/nozzle/ui/PropertyPanel.tsx`. This ensures consistent usage of labels across the application.
* Updated button labels in the `PropertyPanel` component to use values from the `Materials` object instead of hardcoding strings directly.

### Form Submission Update:

* Modified the form submission URL in the `PropertyPanel` component to include the selected material label from the `Materials` object, improving maintainability and ensuring accurate data encoding.

### Type Definition:

* Retained the `Material` type definition in `src/stores/nozzle.ts`, which supports the refactored code.